### PR TITLE
Fix: Make more compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ require('babel-core/register')
 hexo.extend.renderer.register('jsx', 'html', function (data, locals) {
   var js = babel.transform(data.text, { filename: data.path })
   var Component = reval(js.code, data.path, null, true)
-  var element = React.createElement(Component, locals)
+  var element = React.createElement(Component.default || Component, locals)
   var markup = ReactDOMServer.renderToStaticMarkup(element);
 
   if(markup.match(/^<html/)) {


### PR DESCRIPTION
I found that there is some compatiblity issue between `React.createClass` and `class extends React.Component`.

When using `React.createClass`, we got something like `{ [Function] displayName: 'exports' }`.
When using `class` syntax, we got something like `{ default: [Function: _class] }`.

If we use `class` syntax, hexo server will throw error:

```
Warning: React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components).
Unhandled rejection Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
```

This pull request is trying to solve this problem.
