### PR TITLE
Add react-dom to readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Install
 
 ``` bash
-$ npm install hexo-renderer-react react --save
+$ npm install hexo-renderer-react react react-dom --save
 ```
 
 This requires you to have `react` installed as well.


### PR DESCRIPTION
react-dom is a peer dependency and should be included here with npm v3. this still works with npm v2.
